### PR TITLE
Per-Zone Configs, Configurable Zone Materials, and style refresh to make a specific part readable.

### DIFF
--- a/Simple Spawn Zones/howdoesthiswork.txt
+++ b/Simple Spawn Zones/howdoesthiswork.txt
@@ -22,5 +22,20 @@ Change config options as needed.  Remember to put a comma after the end of every
 While ingame you can open console and type safezone_grablocation into it, this will print the location that your crosshair is pointing at.
 Then you just copy paste that code into the table and you should be good to go
 
+Additionally, if you wish to override the SafezonesConfig settings PER ZONE, you can modify the safezone to have a third argument, basically a copy of the config but with the changes you want.
+For example:
+
+Safezones = {
+["Box1"] = {Vector(11975, 4788, -410), Vector(11594, 6594, -200), {
+    ["ProtectionDelay"] = 5, -- how long will they remain spawn protected after leaving a safezone box
+    ["RemoveProps"] = false, -- do we want to delete props that enter the zones
+    ["RemoveVehicles"] = false, -- do we want to delete vehicles that enter the zones, be careful with this if you run an rp server with cars
+    ["RemoveNPCs"] = false, -- do we want to delete npcs that enter the spawn area
+}},
+["Box2"] = {Vector(6452, 11320, -410), Vector(7684, 12696, -250)},
+}
+
+Note that this is entirely optional, and if you don't specify it, it will use the default config.
+
 
 That should be all you need to know, if you have any problems comment on the scriptfodder page or open a support ticket.  I usually don't accept random adds on steam so don't waste your time adding me.

--- a/Simple Spawn Zones/lua/autorun/server/sv_safezones.lua
+++ b/Simple Spawn Zones/lua/autorun/server/sv_safezones.lua
@@ -31,7 +31,7 @@ local function LoadMapSetup()
 		end
 	end
 
-	if !loadedmap then 
+	if !loadedmap then
 		MsgC(Color(255,50,0), "Simple Safezones: no config detected for this map! check addons/Simple Spawn Zones/sh_safezones.lua for more info\n")
 	end
 
@@ -49,25 +49,30 @@ local function BoxCheck()
 
 for k, v in pairs(MapSZs) do
 	local checkmydubs = ents.FindInBox(v[1], v[2])
-
+	local BoxConfig = table.Copy(SafezonesConfig)
+	if v[3] then
+		for k2,v2 in pairs(v[3]) do
+				BoxConfig[k2] = v2 -- Only overwrite what's been changed, if anything. This allows for per-zone config changes without having to copy paste the ENTIRE config.'
+		end
+	end
 	for k, v in pairs(checkmydubs) do
 	if v:IsPlayer() and v:IsValid() then
-		if not SafezonesConfig["RecurringProtection"] and v.PreviouslyProtected then return end
+		if not BoxConfig["RecurringProtection"] and v.PreviouslyProtected then return end
 		v:SetNWBool("SpawnProtected", true )
-		if SafezonesConfig["BlockTracesToPlayer"] then v:SetNotSolid( true ) end
-		if SafezonesConfig["TransparencyEffect"] then
+		if BoxConfig["BlockTracesToPlayer"] then v:SetNotSolid( true ) end
+		if BoxConfig["TransparencyEffect"] then
 			local c = v:GetColor()
 			v:SetRenderMode(RENDERMODE_TRANSALPHA)
 			v:SetColor(Color(c.r, c.g, c.b, 100))
 		end
 
-		timer.Create("spawnprot_"..v:UniqueID(), SafezonesConfig["ProtectionDelay"], 1, function()
+		timer.Create("spawnprot_"..v:UniqueID(), BoxConfig["ProtectionDelay"], 1, function()
 			if !v:IsValid() then return false end
 			v:SendLua([[if Legs then Legs:SetUp() end]]) -- this is a really dodgy solution but i can't really think of a better way because this timer doesnt exist on the client
 			v:SetNWBool("SpawnProtected", false)
-			if SafezonesConfig["BlockTracesToPlayer"] then v:SetNotSolid( false ) end
-			if !SafezonesConfig["RecurringProtection"] then v.PreviouslyProtected = true end
-			if SafezonesConfig["TransparencyEffect"] then
+			if BoxConfig["BlockTracesToPlayer"] then v:SetNotSolid( false ) end
+			if !BoxConfig["RecurringProtection"] then v.PreviouslyProtected = true end
+			if BoxConfig["TransparencyEffect"] then
 				local c = v:GetColor()
 				v:SetRenderMode(RENDERMODE_NORMAL)
 				v:SetColor(Color(c.r, c.g, c.b, 100))
@@ -75,19 +80,19 @@ for k, v in pairs(MapSZs) do
 		end)
 	end
 
-	if SafezonesConfig["RemoveProps"] and ((v:GetClass() == "prop_physics" and !v.jailWall) or string.find(v:GetClass(), "wire")) then
+	if BoxConfig["RemoveProps"] and ((v:GetClass() == "prop_physics" and !v.jailWall) or string.find(v:GetClass(), "wire")) then
 		v:Remove()
 	end
 
-	if SafezonesConfig["RemoveVehicles"] and v:IsVehicle() then
+	if BoxConfig["RemoveVehicles"] and v:IsVehicle() then
 		v:Remove()
 	end
 
-	if SafezonesConfig["RemoveNPCs"] and (v:IsNPC() or v.Type == "nextbot") then
+	if BoxConfig["RemoveNPCs"] and (v:IsNPC() or v.Type == "nextbot") then
 		v:Remove()
 	end
 
-	if SafezonesConfig["RemovePysobjects"] and v:GetPhysicsObject():IsValid() and !v:IsPlayer() and !v.jailWall then
+	if BoxConfig["RemovePysobjects"] and v:GetPhysicsObject():IsValid() and !v:IsPlayer() and !v.jailWall then
 		v:Remove()
 	end
 

--- a/Simple Spawn Zones/lua/autorun/sh_safezones.lua
+++ b/Simple Spawn Zones/lua/autorun/sh_safezones.lua
@@ -8,6 +8,7 @@ SafezonesConfig = {
 	["TransparencyEffect"] = true, -- should spawn protected players be transparent?
 	["InvisibleSpawnBoxes"] = false, -- should the spawn protection boxes be invisible?
 	["BlockTracesToPlayer"] = false, -- stops traces from being able to hit the player, this will make them unable to be arrested, shot, cuffed, kidnapped etc
+	["BoxMaterial"] = Material("effects/com_shield003a"), -- what material should we use for the safe zones? Refractive materials will appear VERY broken, only use transparent materials. Also, we wrap the material in the Material() function like so, it's more performant to precache it like this.'
 }
 
 -- the actual boxes, needs to be 2 vectors seperated by a comma as you can see below
@@ -37,6 +38,7 @@ Safezones = {
 			["TransparencyEffect"] = true,
 			["InvisibleSpawnBoxes"] = false,
 			["BlockTracesToPlayer"] = false,
+			["BoxMaterial"] = Material("effects/comball_tape"),
 		}}
 	},
 
@@ -95,7 +97,7 @@ local function DrawSpawnBoxes()
 			end
 		end
 		if BoxConfig["InvisibleSpawnBoxes"] then return end
-		render.SetMaterial( Material("effects/com_shield003a") )
+		render.SetMaterial( BoxConfig["BoxMaterial"] )
 		render.DrawBox( v[2], Angle(0,0,0), Vector(0,0,0), v[1] - v[2], Color(255,0,0, 100), true )
 	end
 end

--- a/Simple Spawn Zones/lua/autorun/sh_safezones.lua
+++ b/Simple Spawn Zones/lua/autorun/sh_safezones.lua
@@ -12,6 +12,7 @@ SafezonesConfig = {
 
 -- the actual boxes, needs to be 2 vectors seperated by a comma as you can see below
 -- you can type safezone_grablocation into console to grab the vector location of what your crosshair is pointing at, then copy paste it into this file
+-- you can additionally modify the above config in a third argument, this will override the default config. See gm_cfgrass_deathminge_v1 for an example of how that's done.'
 
 Safezones = {
 
@@ -26,6 +27,17 @@ Safezones = {
 	["gm_cfgrass_deathminge_v1"] = {
 		["Box1"] = {Vector(11975, 4788, -410), Vector(11594, 6594, -200)},
 		["Box2"] = {Vector(6452, 11320, -410), Vector(7684, 12696, -250)},
+		["Water"] = {Vector( 3672, -4112, -2 ), Vector( 14319, -7650, 2668 ), {
+			["ProtectionDelay"] = 3,
+			["RemoveProps"] = false,
+			["RemovePysobjects"] = false,
+			["RemoveVehicles"] = false,
+			["RemoveNPCs"] = false,
+			["RecurringProtection"] = true,
+			["TransparencyEffect"] = true,
+			["InvisibleSpawnBoxes"] = false,
+			["BlockTracesToPlayer"] = false,
+		}}
 	},
 
 	["gm_freespace_13"] = {
@@ -37,7 +49,7 @@ Safezones = {
 	},
 
 	["rp_downtown_v4c_v3"] = {
-    	["Box1"] = {Vector(-1453, -1151, -194), Vector(-2347, -1985, 36)},
+		["Box1"] = {Vector(-1453, -1151, -194), Vector(-2347, -1985, 36)},
 	},
 
 }
@@ -66,7 +78,7 @@ local function LoadMapSetup()
 		end
 	end
 
-	if !loadedmap then 
+	if !loadedmap then
 		MsgC(Color(255,50,0), "Simple Safezones: no config detected for this map! check addons/Simple Spawn Zones/sh_safezones.lua for more info\n")
 	end
 
@@ -74,9 +86,16 @@ end
 timer.Simple(1, function() LoadMapSetup() end)
 
 local function DrawSpawnBoxes()
-	if SafezonesConfig["InvisibleSpawnBoxes"] then return end
-	render.SetMaterial( Material("effects/com_shield003a") )
+
 	for k, v in pairs(MapSZs) do
+		local BoxConfig = table.Copy(SafezonesConfig)
+		if v[3] then
+			for k2,v2 in pairs(v[3]) do
+				BoxConfig[k2] = v2
+			end
+		end
+		if BoxConfig["InvisibleSpawnBoxes"] then return end
+		render.SetMaterial( Material("effects/com_shield003a") )
 		render.DrawBox( v[2], Angle(0,0,0), Vector(0,0,0), v[1] - v[2], Color(255,0,0, 100), true )
 	end
 end

--- a/Simple Spawn Zones/lua/autorun/sh_safezones.lua
+++ b/Simple Spawn Zones/lua/autorun/sh_safezones.lua
@@ -63,7 +63,7 @@ if CLIENT then
 
 -- use this to easily grab locations for your spawn boxes
 local function GrabLoc()
-print("Vector( "..math.floor(LocalPlayer():GetEyeTrace().HitPos.x)..", "..math.floor(LocalPlayer():GetEyeTrace().HitPos.y)..", "..math.floor(LocalPlayer():GetEyeTrace().HitPos.z).." )")
+print("Vector( " .. math.floor(LocalPlayer():GetEyeTrace().HitPos.x) .. ", " .. math.floor(LocalPlayer():GetEyeTrace().HitPos.y) .. ", " .. math.floor(LocalPlayer():GetEyeTrace().HitPos.z) .. " )")
 end
 concommand.Add("safezone_grablocation", GrabLoc)
 


### PR DESCRIPTION
Some QOL stuff I added while tweaking for a... certain server... that might be on it's way back.

1. Per Zone configurations: You can now (optionally) modify the global config per zone. Useful if you want a protected build zone that won't erase props or vehicles, but you still want a prop free spawn.
2. Box Material tweaks: You can now configure (and per-zone) the material for each box. I've also elected to precaching the material for each box PRIOR to use, rather than in a per-frame executed function. Word on the street is that this is slightly more performant than the existing code.
3. Reformatted code to closer align with the glualinter (also improves readability).

Note: I may in the future add something to customize the message per zone when a user enters or exits. At the moment it's a little beyond scope, as I'd have to implement networked strings and then also think about "what if the user goes from one zone to another and back" and so on so forth. It's a bit of a non issue really.